### PR TITLE
Issue #12

### DIFF
--- a/uvls/src/core/ast.rs
+++ b/uvls/src/core/ast.rs
@@ -295,6 +295,9 @@ impl AstDocument {
             .flat_map(|i| i.iter())
             .cloned()
     }
+    pub fn get_reference(&self, index: usize) -> Option<&Reference> {
+        self.ast.references.get(index)
+    }
     pub fn lsp_range(&self, sym: Symbol) -> Option<tower_lsp::lsp_types::Range> {
         self.ast.lsp_range(sym, &self.source)
     }

--- a/uvls/src/ide/location.rs
+++ b/uvls/src/ide/location.rs
@@ -281,8 +281,23 @@ fn find_definitions(
                 },
             );
             Some(out)
+        },
+        TextObjectKind::Feature => {
+            for i in root.resolve(file_id, &obj.path.names) {
+                if matches!(i.sym, Symbol::Feature(_)) {
+                    return Some(vec![i]);
         }
-        _ => None,
+            }
+            None
+        },
+        TextObjectKind::Attribute => {
+            for i in root.resolve(file_id, &obj.path.names) {
+                if matches!(i.sym, Symbol::Attribute(_)) {
+                    return Some(vec![i]);
+                }
+            }
+            None
+        }
     }
 }
 pub fn goto_definition(

--- a/uvls/src/ide/location.rs
+++ b/uvls/src/ide/location.rs
@@ -330,10 +330,6 @@ pub fn goto_definition(
 }
 
 fn reverse_resolve(root: &Snapshot, dst_id: FileID, tgt: Symbol) -> Vec<(RootSymbol, Option<Range>)> {
-    let ty = root.type_of(RootSymbol {
-        sym: tgt,
-        file: dst_id,
-    });
     let dst_file = root.file(dst_id);
 
     root.fs()
@@ -344,9 +340,6 @@ fn reverse_resolve(root: &Snapshot, dst_id: FileID, tgt: Symbol) -> Vec<(RootSym
 
             src_file
                 .all_references()
-                .filter(move |r| {
-                    root.type_of(RootSymbol {sym: *r,file: src_id,}) == ty
-                })
                 .filter(move |r| {
                     root.resolve(src_id, src_file.path(*r)).any(|sym|
                         sym == RootSymbol {file: dst_id,sym: tgt,} ||

--- a/uvls/src/main.rs
+++ b/uvls/src/main.rs
@@ -172,6 +172,7 @@ impl LanguageServer for Backend {
                     ),
                 ),
                 references_provider: Some(OneOf::Left(true)),
+                rename_provider : Some(OneOf::Left(true)),
                 code_lens_provider: Some(CodeLensOptions {
                     resolve_provider: Some(true),
                 }),
@@ -264,6 +265,20 @@ impl LanguageServer for Backend {
         let uri = &params.text_document_position.text_document.uri;
         if let Some((draft, root)) = self.snapshot(uri, true).await? {
             Ok(ide::location::find_references(
+                &root,
+                &draft,
+                &params.text_document_position.position,
+                uri,
+            ))
+        } else {
+            return Ok(None);
+        }
+    }
+    async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
+        info!("[RENAME] params: {:?}", params);
+        let uri = &params.text_document_position.text_document.uri;
+        if let Some((draft, root)) = self.snapshot(uri, true).await? {
+            Ok(ide::location::rename(
                 &root,
                 &draft,
                 &params.text_document_position.position,

--- a/uvls/src/main.rs
+++ b/uvls/src/main.rs
@@ -281,8 +281,9 @@ impl LanguageServer for Backend {
             Ok(ide::location::rename(
                 &root,
                 &draft,
-                &params.text_document_position.position,
                 uri,
+                &params.text_document_position.position,
+                params.new_name
             ))
         } else {
             return Ok(None);


### PR DESCRIPTION
For this Issue (fixes https://github.com/Universal-Variability-Language/uvl-lsp/issues/12) we adjusted the `Find All References` to actually find all references. Before that, this function did not find `feature.attr` if `feature` was searched for.  
Additionally, only the `feature` part is referenced (not the whole symbol).  
Core function: Renaming is now possible (also by pressing `F2`).

You can see a simple demo in this gif:  
![issue_12](https://github.com/Universal-Variability-Language/uvl-lsp/assets/131375895/81b0a88b-be1f-45d1-b6a0-5e1b5b00ddf1)

Note:  
Obviously, renaming should find all references of the current definition (across all imported files).  
However, a reference within a different file can only be found if this file is loaded (and therefore opened within the editor).  
Further functionality (like finding references in the current directory/folder) requires another adjustments.  
Please check if this is needed.