### PR TITLE
Issue #26

### DIFF
--- a/uvls/src/core/ast/transform.rs
+++ b/uvls/src/core/ast/transform.rs
@@ -1175,6 +1175,7 @@ pub fn visit_root(source: Rope, tree: Tree, uri: Url, timestamp: Instant) -> Ast
         state.connect();
         (state.ast, state.errors)
     };
+    info!("[TRANSFORM] visit_root uri = {:?}", uri);
     let mut path = uri_to_path(&uri).unwrap();
     if let Some(ns) = ast.namespace.as_ref() {
         let len = path.len().saturating_sub(ns.names.len());

--- a/uvls/src/core/ast/transform.rs
+++ b/uvls/src/core/ast/transform.rs
@@ -557,7 +557,6 @@ fn opt_function_args(state: &mut VisitorState) -> Option<Vec<Path>> {
 }
 
 fn check_langlvls(state: &mut VisitorState, searched_lang_lvl: LanguageLevel) {
-    //info!("[check_langlvls] Search for: {:?}", searched_lang_lvl);
 
     if state.ast.includes.is_empty() { // no includes means, that implicitly everything is included
         return ();
@@ -1175,7 +1174,6 @@ pub fn visit_root(source: Rope, tree: Tree, uri: Url, timestamp: Instant) -> Ast
         state.connect();
         (state.ast, state.errors)
     };
-    info!("[TRANSFORM] visit_root uri = {:?}", uri);
     let mut path = uri_to_path(&uri).unwrap();
     if let Some(ns) = ast.namespace.as_ref() {
         let len = path.len().saturating_sub(ns.names.len());

--- a/uvls/src/core/cache.rs
+++ b/uvls/src/core/cache.rs
@@ -102,8 +102,14 @@ impl FileSystem {
             file2node.insert(n, id);
         }
         //resolve imports
+        info!("[CACHE] graph {:?}", graph);
+        info!("[CACHE] file2node {:?}", file2node);
         for (&n, f) in files.iter() {
+            info!("[CACHE] Check for file {:?}", n);
             for i in f.all_imports().rev() {
+                info!("[CACHE] Check for import {:?}", i);
+                info!("[CACHE] file.path {:?}", f.path(i));
+                info!("[CACHE] goto_file {:?}", Self::goto_file(&graph, file2node[&n], f.path(i)));
                 if let Some(node) = Self::goto_file(&graph, file2node[&n], f.path(i)) {
                     if graph.contains_edge(node, file2node[&n]) {
                         errors.sym(i, n, 50, "cyclic import not allowed");

--- a/uvls/src/core/cache.rs
+++ b/uvls/src/core/cache.rs
@@ -102,14 +102,8 @@ impl FileSystem {
             file2node.insert(n, id);
         }
         //resolve imports
-        info!("[CACHE] graph {:?}", graph);
-        info!("[CACHE] file2node {:?}", file2node);
         for (&n, f) in files.iter() {
-            info!("[CACHE] Check for file {:?}", n);
             for i in f.all_imports().rev() {
-                info!("[CACHE] Check for import {:?}", i);
-                info!("[CACHE] file.path {:?}", f.path(i));
-                info!("[CACHE] goto_file {:?}", Self::goto_file(&graph, file2node[&n], f.path(i)));
                 if let Some(node) = Self::goto_file(&graph, file2node[&n], f.path(i)) {
                     if graph.contains_edge(node, file2node[&n]) {
                         errors.sym(i, n, 50, "cyclic import not allowed");

--- a/uvls/src/core/pipeline.rs
+++ b/uvls/src/core/pipeline.rs
@@ -150,7 +150,6 @@ struct DraftState {
     timestamp: Instant,
 }
 
-#[derive(Debug)]
 enum LinkMsg {
     Delete(Url, Instant),
     UpdateAst(Arc<ast::AstDocument>),
@@ -372,7 +371,6 @@ impl AsyncPipeline {
                 }
             }
         }
-
     }
     pub fn should_load(&self, uri: &Url, time: SystemTime) -> bool {
         self.drafts

--- a/uvls/src/core/pipeline.rs
+++ b/uvls/src/core/pipeline.rs
@@ -166,8 +166,6 @@ async fn link_handler(
     let mut latest_configs: HashMap<FileID, Arc<config::ConfigDocument>> = HashMap::new();
     let mut latest_ast: HashMap<FileID, Arc<ast::AstDocument>> = HashMap::new();
     let mut timestamps: HashMap<Url, Instant> = HashMap::new();
-    // info!("[PIPELINE] empty, latest_ast = {:?}", latest_ast);
-    // info!("[PIPELINE] empty, latest_configs = {:?}", latest_configs);
     let (tx_execute, rx_execute) = watch::channel((latest_ast.clone(), latest_configs.clone(), 0));
     let mut dirty = false;
     let mut revision = 0;//Each change is one revision
@@ -177,7 +175,6 @@ async fn link_handler(
     loop {
         select! {
             Some(msg)=rx.recv()=>{
-                //info!("[PIPELINE] rx.recv msg = {:?}", msg);
                 match msg{
                     LinkMsg::Delete(uri,timestamp)=>{
                         if timestamps.get(&uri).map(|old|old < &timestamp).unwrap_or(true){
@@ -256,9 +253,7 @@ async fn link_handler(
             let old = tx_cache.borrow().cache().clone();
 
             //link files incrementally
-            info!("[PIPELINE] link_executor, AstFiles: {:?}", ast);
             let root = RootGraph::new(&ast, &configs, revision, &old, &mut err, &mut timestamps);
-            info!("[PIPELINE] link_executor, RootGraph: {:?}", root);
 
             let _ = tx_cache.send(Arc::new(root));
             let _ = tx_err
@@ -377,6 +372,7 @@ impl AsyncPipeline {
                 }
             }
         }
+
     }
     pub fn should_load(&self, uri: &Url, time: SystemTime) -> bool {
         self.drafts

--- a/uvls/src/main.rs
+++ b/uvls/src/main.rs
@@ -72,7 +72,7 @@ impl Backend {
     }
 }
 //load a file, this is tricky because the editor can also load it at the same time
-fn load_blocking(uri: Url, pipeline: &AsyncPipeline) {    
+fn load_blocking(uri: Url, pipeline: &AsyncPipeline) {
     if let Err(e) = std::fs::File::open(uri.to_file_path().unwrap()).and_then(|mut f| {
         let meta = f.metadata()?;
         let modified = meta.modified()?;

--- a/uvls/src/main.rs
+++ b/uvls/src/main.rs
@@ -73,23 +73,16 @@ impl Backend {
 }
 //load a file, this is tricky because the editor can also load it at the same time
 fn load_blocking(uri: Url, pipeline: &AsyncPipeline) {    
-    if let Err(e) = std::fs::File::open(uri.path()).and_then(|mut f| {
-        info!("[MAIN] load_blocking 00");
+    if let Err(e) = std::fs::File::open(uri.to_file_path().unwrap()).and_then(|mut f| {
         let meta = f.metadata()?;
         let modified = meta.modified()?;
 
-        info!("[MAIN] load_blocking 01");
-        //let newuri = Url::from_file_path(Path::new(uri.path())).unwrap();
-        //info!("[MAIN] load_blocking newuri = {:?}", newuri);
         if !pipeline.should_load(&uri, modified) {
             return Ok(());
         }
-        info!("[MAIN] load_blocking 02");
         let mut data = String::new();
         f.read_to_string(&mut data)?;
-        info!("[MAIN] load_blocking 03");
         pipeline.open(uri.clone(), data, DocumentState::OwnedByOs(modified));
-        info!("[MAIN] load_blocking 04");
         Ok(())
     }) {
         info!("Failed to load file {} : {}", uri, e);
@@ -97,33 +90,18 @@ fn load_blocking(uri: Url, pipeline: &AsyncPipeline) {
 }
 //load all files under given a path
 fn load_all_blocking(path: &Path, pipeline: AsyncPipeline) {
-    info!("[MAIN] load_all_blocking path = {:?}", path);
     for e in walkdir::WalkDir::new(path)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.path().is_file())
         .filter(|e| {
-            info!("[MAIN] load_all_blocking file path = {:?}", e.path());
-            info!("[MAIN] load_all_blocking file extension = {:?}", e.path().extension());
             e.path()
                 .extension()
                 .map(|e| e == std::ffi::OsStr::new("uvl"))
                 .unwrap_or(false)
         })
     {
-        info!("[MAIN] load_all_blocking path = {:?}", e);
-        /*if e.path().to_string_lossy().contains("test.uvl"){
-            let p = Path::new("C:/uvl_test/test.uvl");
-            info!("[MAIN] load_all_blocking path01 = {:?}", p);
-            load_blocking(Url::parse(p.to_str().unwrap()).unwrap(), &pipeline)
-        }else if e.path().to_string_lossy().contains("test2.uvl") {
-            let p = Path::new("C:/uvl_test/test2.uvl");
-            info!("[MAIN] load_all_blocking path02 = {:?}", p);
-            load_blocking(Url::parse(p.to_str().unwrap()).unwrap(), &pipeline)
-        } else {*/
-            info!("[MAIN] load_all_blocking path03 = {:?}", e.path());
-            load_blocking(Url::from_file_path(e.path()).unwrap(), &pipeline)
-        //}
+        load_blocking(Url::from_file_path(e.path()).unwrap(), &pipeline)
     }
 }
 fn shutdown_error() -> tower_lsp::jsonrpc::Error {
@@ -147,7 +125,6 @@ impl LanguageServer for Backend {
             let semantic = self.pipeline.clone();
             //cheap fix for better intial load, we should really use priority model to prefer
             //editor owned files
-            info!("[Backend] root_folder = {:?}", root_folder);
             spawn(async move {
                 tokio::task::spawn_blocking(move || {
                     load_all_blocking(&root_folder, semantic);


### PR DESCRIPTION
Fixes https://github.com/Universal-Variability-Language/uvl-lsp/issues/26  
as you can see the fix is minimal and can be reduced to `uri.to_file_path()` instead of `uri.path()`
@felixrieg confirmed that it does not change anything on non-windows systems.