### PR TITLE
add vsCode graph button

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -40,7 +40,8 @@
       {
         "command":"uvls.generate_diagram",
         "title": "Generate a DOT file to visualize with Graphviz",
-        "category": "UVLS"
+        "category": "UVLS",
+        "icon": "$(repo-forked)"
       }
     ],
     "languages": [
@@ -93,7 +94,22 @@
 					"light": "#ffef93d2"
         }
       }
-    ]
+    ],
+    "keybindings": [
+        {
+          "command": "uvls.generate_diagram",
+          "key": "ctrl+G",
+          "mac": "cmd+G",
+          "when": "editorLangId == uvl"
+        }
+    ],
+    "menus": {
+        "editor/title": [{
+            "command": "uvls.generate_diagram",
+            "group": "navigation",
+            "when": "editorLangId == uvl"
+        }]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",


### PR DESCRIPTION
Makes https://github.com/Universal-Variability-Language/uvl-lsp/issues/8 more convenient.  
Adds simple vsCode ui buttons + keyboard shortcuts (`Ctrl + G`) to generate a graph + `.dot` file from a UVL Feature Model.  
Preview:  
<img  alt="Graph vsCode button preview" src="https://user-images.githubusercontent.com/131375895/245472876-1090443b-473c-448c-b23b-32b7291438bc.gif">
