### PR TITLE
Issue #23 Collapse UVL Features to Certain Level

### DIFF
--- a/uvls/src/core/ast.rs
+++ b/uvls/src/core/ast.rs
@@ -14,6 +14,7 @@ mod def;
 mod transform;
 mod visitor;
 pub mod graph;
+pub mod collapse;
 pub use def::*;
 pub use visitor::*;
 //Easy to work with AST parsing and util.

--- a/uvls/src/core/ast/collapse.rs
+++ b/uvls/src/core/ast/collapse.rs
@@ -1,0 +1,200 @@
+use crate::core::*;
+use ast::visitor::Visitor;
+use ast::visitor::*;
+use check::ErrorInfo;
+use parse::*;
+use ropey::Rope;
+use std::borrow::Cow;
+use tower_lsp::lsp_types::{FoldingRange, Url};
+use tree_sitter::{Node, Tree, TreeCursor};
+
+#[derive(Debug)]
+pub struct Collapse {
+    pub ranges: Vec<FoldingRange>,
+    pub uri: Url,
+}
+impl Collapse {
+    pub fn new(source: Rope, tree: Tree, uri: Url) -> Self {
+        visit_root(source, tree, uri)
+    }
+}
+
+//Transform a tree-sitter tree into the Ast ECS via recursive decent
+//While parsing we keep a mutable state to store entities and errors
+#[derive(Clone)]
+struct VisitorCollapse<'a> {
+    cursor: TreeCursor<'a>,
+    ranges: Vec<FoldingRange>,
+    source: &'a Rope,
+    root_name: Option<String>,
+    current_level: usize,
+    levels: Vec<usize>,
+}
+impl<'a> Visitor<'a> for VisitorCollapse<'a> {
+    fn cursor(&self) -> &TreeCursor<'a> {
+        &self.cursor
+    }
+    fn cursor_mut(&mut self) -> &mut TreeCursor<'a> {
+        &mut self.cursor
+    }
+    fn source(&self) -> &Rope {
+        self.source
+    }
+    fn push_err_raw(&mut self, _: ErrorInfo) {}
+}
+
+impl<'a> VisitorCollapse<'a> {
+    fn add_range(&mut self, start: usize, end: usize) -> () {
+        self.ranges.push(FoldingRange {
+            start_line: start as u32,
+            start_character: None,
+            end_line: end as u32,
+            end_character: None,
+            kind: None,
+            collapsed_text: None,
+        });
+    }
+
+    //get the current block header
+    fn header(&self) -> Option<Node<'a>> {
+        self.node().child_by_field_name("header")
+    }
+
+    fn set_line_level(&mut self) -> () {
+        let line = self.line();
+        self.levels[line] = self.current_level;
+    }
+
+    // Add ranges based on self.levels vec
+    fn calculate_ranges(&mut self) -> () {
+        // Skip comments
+        let first_nonzero_line = self
+            .levels
+            .iter()
+            .enumerate()
+            .find(|(_, e)| e != &&0)
+            .unwrap_or((0, &0))
+            .0;
+        for line in (0..self.levels.len() - 1).rev() {
+            if self.levels[line] != 0 || line < first_nonzero_line {
+                continue;
+            }
+            self.levels[line] = self.levels[line + 1];
+        }
+
+        let mut range_stack: Vec<(usize, usize)> = vec![];
+        for line in 0..self.levels.len() {
+            let level = self.levels[line];
+            let next = *self.levels.get(line + 1).unwrap_or(&0);
+            if level < next {
+                range_stack.push((line, level));
+            } else if level > next {
+                while range_stack.len() > next {
+                    let (start_line, _) = range_stack.pop().unwrap();
+                    self.add_range(start_line, line);
+                }
+            }
+        }
+    }
+
+    fn line(&self) -> usize {
+        self.source.byte_to_line(self.node().byte_range().start)
+    }
+}
+impl<'b> SymbolSlice for VisitorCollapse<'b> {
+    fn slice_raw(&self, node: Span) -> Cow<'_, str> {
+        self.source.byte_slice(node).into()
+    }
+}
+
+fn visit_feature(collapse: &mut VisitorCollapse) {
+    loop {
+        if collapse.cursor().node().kind() == "blk" {
+            visit_children(collapse, visit_blk_decl);
+        }
+        if !collapse.goto_next_sibling() {
+            break;
+        }
+    }
+}
+fn visit_group(collapse: &mut VisitorCollapse) {
+    loop {
+        if collapse.kind() == "blk" {
+            visit_children(collapse, visit_blk_decl);
+        }
+        if !collapse.goto_next_sibling() {
+            break;
+        }
+    }
+}
+fn visit_blk_decl(collapse: &mut VisitorCollapse) {
+    collapse.current_level += 1;
+    collapse.set_line_level();
+    collapse.goto_field("header");
+    match collapse.kind() {
+        "name" | "typed_feature" => {
+            visit_feature(collapse);
+        }
+        "group_mode" | "cardinality" => {
+            visit_group(collapse);
+        }
+        _ => {}
+    }
+    collapse.current_level -= 1;
+}
+
+fn visit_features(collapse: &mut VisitorCollapse) {
+    collapse.set_line_level();
+    loop {
+        if collapse.kind() == "blk" {
+            visit_children(collapse, visit_blk_decl);
+        }
+        if !collapse.goto_next_sibling() {
+            break;
+        }
+    }
+    collapse.calculate_ranges();
+}
+
+fn add_range_of_current_level(collapse: &mut VisitorCollapse) {
+    let start = collapse.line();
+    while collapse.goto_next_sibling() {}
+    collapse.add_range(start, collapse.line());
+}
+
+fn visit_top_lvl(collapse: &mut VisitorCollapse) {
+    let mut top_level_order: Vec<Node> = Vec::new();
+    loop {
+        if collapse.kind() == "blk" {
+            let header = collapse.header().unwrap();
+            top_level_order.push(header);
+            match header.kind() {
+                "include" | "imports" | "constraints" => {
+                    visit_children(collapse, add_range_of_current_level)
+                }
+                "features" => visit_children(collapse, visit_features),
+                _ => {}
+            }
+        }
+        if !collapse.goto_next_sibling() {
+            break;
+        }
+    }
+}
+//visits all valid children of a tree-sitter (red tree) recursively to translate them into the
+//Collapse struct
+pub fn visit_root(source: Rope, tree: Tree, uri: Url) -> Collapse {
+    let mut c = VisitorCollapse {
+        cursor: tree.walk(),
+        ranges: vec![],
+        source: &source,
+        root_name: None,
+        current_level: 0,
+        levels: vec![0; source.lines().len()],
+    };
+    visit_children(&mut c, visit_top_lvl);
+    Collapse {
+        ranges: c.ranges,
+        uri,
+    }
+}

--- a/uvls/src/main.rs
+++ b/uvls/src/main.rs
@@ -4,14 +4,14 @@
 use flexi_logger::FileSpec;
 use get_port::Ops;
 
-use serde::Serialize;
-use tokio::{join, spawn};
 use log::info;
+use percent_encoding::percent_decode_str;
+use serde::Serialize;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use percent_encoding::percent_decode_str;
 use std::sync::Arc;
 use std::time::SystemTime;
+use tokio::{join, spawn};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
@@ -174,7 +174,7 @@ impl LanguageServer for Backend {
                 ),
                 folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
                 references_provider: Some(OneOf::Left(true)),
-                rename_provider : Some(OneOf::Left(true)),
+                rename_provider: Some(OneOf::Left(true)),
                 code_lens_provider: Some(CodeLensOptions {
                     resolve_provider: Some(true),
                 }),
@@ -252,10 +252,16 @@ impl LanguageServer for Backend {
         let uri = params.text_document.uri;
         let root_fileid = FileID::from_uri(&Url::parse(uri.as_str()).unwrap());
         let root_graph = self.pipeline.root().borrow_and_update().clone();
-        if !root_graph.contains_id(root_fileid){return Ok(None);}
-        
+        if !root_graph.contains_id(root_fileid) {
+            return Ok(None);
+        }
+
         let document = root_graph.files.get(&root_fileid).unwrap();
-        let c = ast::collapse::Collapse::new(document.source.clone(), document.tree.clone(), uri.clone());
+        let c = ast::collapse::Collapse::new(
+            document.source.clone(),
+            document.tree.clone(),
+            uri.clone(),
+        );
         Ok(Some(c.ranges))
     }
     async fn goto_definition(
@@ -296,7 +302,7 @@ impl LanguageServer for Backend {
                 &draft,
                 uri,
                 &params.text_document_position.position,
-                params.new_name
+                params.new_name,
             ))
         } else {
             return Ok(None);
@@ -405,22 +411,36 @@ impl LanguageServer for Backend {
             "uvls/generate_diagram" => {
                 let root_fileid = FileID::from_uri(&Url::parse(uri.as_str()).unwrap());
                 let root_graph = self.pipeline.root().borrow_and_update().clone();
-                if !root_graph.contains_id(root_fileid){{}}
-                
+                if !root_graph.contains_id(root_fileid) {
+                    {}
+                }
+
                 let document = root_graph.files.get(&root_fileid).unwrap();
-                let g = ast::graph::Graph::new(document.source.clone(), document.tree.clone(), uri.clone());
+                let g = ast::graph::Graph::new(
+                    document.source.clone(),
+                    document.tree.clone(),
+                    uri.clone(),
+                );
 
                 // write graph script (dot) to file:
                 let diagram_file_extension = "dot";
                 let re = regex::Regex::new(r"(.*\.)(.*)").unwrap();
-                let path = re.replace(uri.path(), |caps: &regex::Captures| {format!("{}{}", &caps[1], diagram_file_extension)});
-                let file = std::fs::File::create(path.as_ref())
-                    .or(std::fs::File::create(percent_decode_str(&path.replacen("/", "", 1)).decode_utf8().unwrap().into_owned())); // windows specific
+                let path = re.replace(uri.path(), |caps: &regex::Captures| {
+                    format!("{}{}", &caps[1], diagram_file_extension)
+                });
+                let file = std::fs::File::create(path.as_ref()).or(std::fs::File::create(
+                    percent_decode_str(&path.replacen("/", "", 1))
+                        .decode_utf8()
+                        .unwrap()
+                        .into_owned(),
+                )); // windows specific
 
                 if file.is_ok() {
-                    file.unwrap().write_all(g.dot.as_bytes()).expect("Error while writing to dot file");
+                    file.unwrap()
+                        .write_all(g.dot.as_bytes())
+                        .expect("Error while writing to dot file");
                 } else {
-                    return Ok(Some(serde_json::to_value(g.dot).unwrap()))
+                    return Ok(Some(serde_json::to_value(g.dot).unwrap()));
                 }
             }
             _ => {}
@@ -461,12 +481,9 @@ impl LanguageServer for Backend {
                             character: 0,
                         },
                     },
-                    command: if self
-                        .pipeline
-                        .inlay_state()
-                        .is_active(ide::inlays::InlaySource::File(semantic::FileID::new(
-                            uri.as_str(),
-                        ))) {
+                    command: if self.pipeline.inlay_state().is_active(
+                        ide::inlays::InlaySource::File(semantic::FileID::new(uri.as_str())),
+                    ) {
                         Some(Command {
                             title: "hide".into(),
                             command: "uvls/hide_config".into(),
@@ -555,7 +572,7 @@ impl LanguageServer for Backend {
                         arguments: Some(vec![uri_json]),
                     }),
                     data: None,
-                }
+                },
             ]))
         }
     }
@@ -575,12 +592,11 @@ fn main() {
 }
 async fn server_main() {
     std::env::set_var("RUST_BACKTRACE", "1");
-    
+
     log_panics::Config::new()
         .backtrace_mode(log_panics::BacktraceMode::Unresolved)
         .install_panic_hook();
 
-    
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
     //only needed for vscode auto update

--- a/uvls/src/main.rs
+++ b/uvls/src/main.rs
@@ -172,6 +172,7 @@ impl LanguageServer for Backend {
                         },
                     ),
                 ),
+                folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
                 references_provider: Some(OneOf::Left(true)),
                 rename_provider : Some(OneOf::Left(true)),
                 code_lens_provider: Some(CodeLensOptions {
@@ -246,6 +247,16 @@ impl LanguageServer for Backend {
             )));
         }
         Ok(None)
+    }
+    async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
+        let uri = params.text_document.uri;
+        let root_fileid = FileID::from_uri(&Url::parse(uri.as_str()).unwrap());
+        let root_graph = self.pipeline.root().borrow_and_update().clone();
+        if !root_graph.contains_id(root_fileid){return Ok(None);}
+        
+        let document = root_graph.files.get(&root_fileid).unwrap();
+        let c = ast::collapse::Collapse::new(document.source.clone(), document.tree.clone(), uri.clone());
+        Ok(Some(c.ranges))
     }
     async fn goto_definition(
         &self,


### PR DESCRIPTION
Fixes https://github.com/Universal-Variability-Language/uvl-lsp/issues/23  
This PR adds syntactical Folding Ranges to the `.uvl` files. You can use `Ctrl + K => Ctrl + <n>` to collapse to a certain level.  
It does not work perfectly, but there is no option to manually give the range a level.  
Use `Ctrl + K => Ctrl + J` to unfold all collapsed lines.  

To be honest, it does not work any better than the VSCode internal Smart Folding, it just handles comments better.

Quick demo:
![issue23](https://github.com/Universal-Variability-Language/uvl-lsp/assets/131375895/1fabc40e-b5dd-4e04-8d7b-bce3e71cc591)



**Formatting**:  
It seems like my formatter ( I also use Rust-Analyzer to format ) does the formatting a bit differently and therefore the `main.rs` file looks very messy although it only has ~2 major changes. 