### PR TITLE
Issue 94: Configurator SAT Checks Do Not Work When Having Constraints Over Submodel Features

### DIFF
--- a/uvls/src/core/ast/transform.rs
+++ b/uvls/src/core/ast/transform.rs
@@ -146,7 +146,7 @@ impl<'a> VisitorState<'a> {
                                 error_type: ErrorType::Any,
                             });
                         }
-                        self.ast.attributes[i].depth = depth;
+                        self.ast.attributes[i].depth = depth + 1;
                         node
                     }
                     _ => scope,
@@ -155,7 +155,12 @@ impl<'a> VisitorState<'a> {
                 scope
             };
             for i in self.ast.children(node) {
-                stack.push((i, new_scope, depth + 1));
+                match i {
+                    Symbol::Feature(_) | Symbol::Constraint(_) | Symbol::Group(_) => {
+                        stack.push((i, new_scope, depth))
+                    }
+                    _ => stack.push((i, new_scope, depth + 1)),
+                }
             }
         }
         //find alias for different symbols and report them


### PR DESCRIPTION
FIxes: #94 

When specifying a cross-tree constraint including features from an imported submodel, the reasoning engine in the configurator does not seem to work.