### PR TITLE
feat(FM-Configuration): Optimize communication to access configure-view 

### DIFF
--- a/uvls/src/main.rs
+++ b/uvls/src/main.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::{join, spawn};
-use tower_lsp::jsonrpc::{Result};
+use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 mod core;

--- a/uvls/src/main.rs
+++ b/uvls/src/main.rs
@@ -373,12 +373,15 @@ impl LanguageServer for Backend {
         match params.command.as_str() {
             "uvls/load_config" => {
                 let target = format!("{}/load{}", self.web_handler_uri, uri.path());
-                let response: serde_json::Value = serde_json::to_value(OpenArgs { uri: target }).expect("Stop bitching me Rust!");
+                let response: serde_json::Value =
+                    serde_json::to_value(OpenArgs { uri: target }).unwrap();
                 return Ok(Some(response));
             }
             "uvls/open_config" => {
                 let target = format!("{}/create{}", self.web_handler_uri, uri.path());
-                let response: serde_json::Value = serde_json::to_value(OpenArgs { uri: target }).expect("Stop bitching me Rust!");
+                info!("{}", target);
+                let response: serde_json::Value =
+                    serde_json::to_value(OpenArgs { uri: target }).unwrap();
                 return Ok(Some(response));
             }
             "uvls/show_config" => {

--- a/uvls/src/webview.rs
+++ b/uvls/src/webview.rs
@@ -823,7 +823,7 @@ pub async fn ui_main(
 //HTTP server for the configuration interface
 pub async fn web_handler(pipeline: AsyncPipeline, port: u16) {
     info!("Starting web handler");
-    let addr: std::net::SocketAddr = ([0, 0, 0, 0], port).into();
+    let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
     let view = dioxus_liveview::LiveViewPool::new();
     let style = include_str!("webview/style.css");
 

--- a/uvls/src/webview.rs
+++ b/uvls/src/webview.rs
@@ -823,7 +823,7 @@ pub async fn ui_main(
 //HTTP server for the configuration interface
 pub async fn web_handler(pipeline: AsyncPipeline, port: u16) {
     info!("Starting web handler");
-    let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
+    let addr: std::net::SocketAddr = ([0, 0, 0, 0], port).into();
     let view = dioxus_liveview::LiveViewPool::new();
     let style = include_str!("webview/style.css");
 


### PR DESCRIPTION
The current interface offers the commands 'open_config' or 'load_config' to fetch the URL to the webview, in which a FM can be configured. However, the URL will be transmitted via a request back to the client with the URL instead of sending it directly as the response.
The PR removes this indirection in the backend and also adapts the vscode extension to handle it properly. 