### PR TITLE
Issue135: Switching usage of the "collapsed" and "expanded" icons in the Frontend

### DIFF
--- a/uvls/src/webview/frontend.rs
+++ b/uvls/src/webview/frontend.rs
@@ -377,11 +377,11 @@ fn FileEntry(cx: Scope, node: UIEntry, leaf: bool, sym: ModuleSymbol, tag: u8) -
                                 ui_task.send(UIAction::ToggleEntry(*sym,*tag))
                             },
                             if node.open{
-                                rsx!{Icon{icon:Icon::Collapse}}
+                                rsx!{Icon{icon:Icon::Expand}}
 
                             }
                             else{
-                                rsx!{Icon{icon:Icon::Expand}}
+                                rsx!{Icon{icon:Icon::Collapse}}
 
                             }
                         }


### PR DESCRIPTION
fixes issue https://github.com/Universal-Variability-Language/uvl-lsp/issues/135

This PR is quite simple, it just switches the usage of the Icons around.
If the node is open, it should use the "Expanded" icon, and if it is closed, it should use the "Collapsed" icon.

Im not sure if you require any testing/ci steps, but this change should be straightforward.